### PR TITLE
chore(ci): add Trufflehog scan workflow [skip ci]

### DIFF
--- a/.github/workflows/trufflehog-scan.yml
+++ b/.github/workflows/trufflehog-scan.yml
@@ -8,10 +8,7 @@ on:
 
 jobs:
   trufflehog-scan:
-    uses: Parsimotion/workflows/.github/workflows/trufflehog-scan.yml@main
+    uses: Parsimotion/public-workflows/.github/workflows/trufflehog-scan.yml@main
     with:
       pr-number: ${{ github.event.pull_request.number }}
       base-commit: ${{ github.event.pull_request.base.sha }}
-    secrets:
-      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/trufflehog-scan.yml
+++ b/.github/workflows/trufflehog-scan.yml
@@ -1,0 +1,17 @@
+name: Trufflehog Scan
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+
+jobs:
+  trufflehog-scan:
+    uses: Parsimotion/workflows/.github/workflows/trufflehog-scan.yml@main
+    with:
+      pr-number: ${{ github.event.pull_request.number }}
+      base-commit: ${{ github.event.pull_request.base.sha }}
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to run Trufflehog scans on PRs.